### PR TITLE
feat: replace the branch name input with branch name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Add the following step to your workflow
 | --- | --- | --- | --- |
 | git_user_name | The name of the git user of the commit |Commit and Push to Protected Branch Action | false |
 | git_user_email | The email of the git user of the commit | <> | false |
-| temp_branch | The name of the temporary branch | temp_${{ github.run_id }}-${{ github.run_attempt } | false |
+| temp_branch_prefix | The prefix of the temporary branch. The complete name will be prefix_runid-runattempt: i.e. branchprefix_4269555185-1 | temp | false |
 | commit_message | The message of the commit that will hold the changes |  | true |

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,10 @@ inputs:
     description: 'The email of the git user of the commit (default: <>)'
     required: false
     default: '<>'
-  temp_branch:
-    description: 'The name of the temporary branch (default: temp_(github.run_id)-(github.run_attempt)'
+  temp_branch_prefix:
+    description: 'The prefix of the temporary branch. The complete name will be prefix_runid-runattempt: i.e. branchprefix_4269555185-1 (default: temp)'
     required: false
-    default: 'temp_${{ github.run_id }}-${{ github.run_attempt }}'
+    default: 'temp'
   commit_message:
     description: 'The message of the commit that will hold the changes'
     required: true
@@ -27,15 +27,22 @@ runs:
       run: |
         git config user.name "${{ inputs.git_user_name }}"
         git config user.email "${{ inputs.git_user_email }}"
+    - name: Build temporary branch name
+      id: temp_branch
+      shell: bash
+      run: |
+        TEMP_BRANCH_PREFIX="${{ inputs.temp_branch_prefix }}_${{ github.run_id }}-${{ github.run_attempt }}"
+        echo "::set-output name=value::$base_branch"
+        echo "value=$TEMP_BRANCH_PREFIX" >> $GITHUB_OUTPUT
     - name: Commit and push the changes to a temporary branch
       shell: bash
       run: |
-        git checkout -b ${{ inputs.temp_branch }}
+        git checkout -b ${{ steps.temp_branch.outputs.value }}
         git add --all
         git commit -m "${{ inputs.commit_message }}"
-        git push -u origin ${{ inputs.temp_branch }}
+        git push -u origin ${{ steps.temp_branch.outputs.value }}
     - name: Push changes to the branch that triggered the workflow (even if its protected)
       shell: bash
       run: |
-        gh pr create --base ${{ github.ref_name }} --head ${{ inputs.temp_branch }} --title "${{ inputs.commit_message }}" --body "This Pull Request has been created by the **Push to Pull Request protected branch** Github Action"
+        gh pr create --base ${{ github.ref_name }} --head ${{ steps.temp_branch.outputs.value }} --title "${{ inputs.commit_message }}" --body "This Pull Request has been created by the **Push to Pull Request protected branch** Github Action"
         gh pr merge --auto --delete-branch --squash


### PR DESCRIPTION
Before the input was about the whole branch name. 

Now the input is just a prefix, so that the logic about generating an unique branch name using run_id and run_attempt can be included in the steps instead of needing to be done outside the Action